### PR TITLE
Add type of component attributes for VueJS

### DIFF
--- a/src/VueSimpleIcon.ts
+++ b/src/VueSimpleIcon.ts
@@ -60,13 +60,13 @@ export default class VueSimpleIcon extends Vue {
   title!: string;
 
   @Prop(Boolean)
-  small!: string;
+  small!: Boolean;
   @Prop(Boolean)
-  medium!: string;
+  medium!: Boolean;
   @Prop(Boolean)
-  large!: string;
+  large!: Boolean;
   @Prop(Boolean)
-  xLarge!: string;
+  xLarge!: Boolean;
   @Prop([String, Number])
   size!: string | number;
 


### PR DESCRIPTION
# Description
Add component attribute types in VueJS. The keyword-based size properties (i.e. `small`, `medium`, `large`, and `xLarge`) are set to _"Boolean"_ as they should be used like `<vue-simple-icon name="Google" small />`.

Based on:
- https://vuejs.org/v2/guide/components-props.html
- https://github.com/kaorun343/vue-property-decorator#readme

I have one question @sh7dm, should the TypeScript type of the size properties be changed to `boolean` as well?

# Why is this change required?
This allows VueJS to verify the type of the value of the attributes we expect automatically for us.

- [x] I've read the contributing guidelines and the Code of Conduct
