### PR TITLE
Fix warning for html attribute

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -13,7 +13,7 @@
     <vue-simple-icon name="Travis CI" medium />
     <vue-simple-icon name="Travis CI" large />
     <vue-simple-icon name="Travis CI" xLarge />
-    <vue-simple-icon name="Travis CI" size=64 />
+    <vue-simple-icon name="Travis CI" size="64" />
     <vue-simple-icon name="Travis CI" size="100" />
 
     <vue-simple-icon name="Travis CI" color="#badcolor" />


### PR DESCRIPTION
<!-- Checklist -->
- [x] I've read the Contributing Guidelines and the Code of Conduct


# Description
Fixed a warning by `yarn serve` in playground about a HTML attribute without quotes.


# Why is this change required?
Not highly important, but just fixing a warning.


# How did you test that?
Ran `yarn serve` again.