### PR TITLE
Render/utilize path property

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "rimraf": "^2.6.3",
-    "simple-icons": "^1.9.28",
+    "simple-icons": "^1.10.0",
     "vue": "^2.6.9",
     "vue-class-component": "^7.0.0",
     "vue-property-decorator": "^8.0.0"

--- a/src/VueSimpleIcon.ts
+++ b/src/VueSimpleIcon.ts
@@ -11,13 +11,7 @@ import { renderError } from "./util";
     if (!icon)
       return renderError("Icon not found", this.iconSize, createElement);
 
-    let svgContent = icon.svg.replace(/<\/?svg[^>]*>/g, "");
-    if (this.title) {
-      svgContent = svgContent.replace(
-        /<title>.*<\/title>/,
-        `<title>${this.title}</title>`
-      );
-    }
+    const title = this.title ? this.title : `${icon.title} icon`;
 
     return createElement("svg", {
       attrs: {
@@ -26,11 +20,15 @@ import { renderError } from "./util";
         height: this.iconSize,
         viewBox: "0 0 24 24",
         xmlns: "http://www.w3.org/2000/svg"
-      },
-      domProps: {
-        innerHTML: svgContent
       }
-    });
+    }, [
+      createElement('title', title),
+      createElement('path', {
+        attrs: {
+          d: icon.path
+        }
+      })
+    ]);
   }
 })
 export default class VueSimpleIcon extends Vue {

--- a/src/VueSimpleIcon.ts
+++ b/src/VueSimpleIcon.ts
@@ -13,22 +13,26 @@ import { renderError } from "./util";
 
     const title = this.title ? this.title : `${icon.title} icon`;
 
-    return createElement("svg", {
-      attrs: {
-        fill: this.color || `#${icon.hex}`,
-        width: this.iconSize,
-        height: this.iconSize,
-        viewBox: "0 0 24 24",
-        xmlns: "http://www.w3.org/2000/svg"
-      }
-    }, [
-      createElement('title', title),
-      createElement('path', {
+    return createElement(
+      "svg",
+      {
         attrs: {
-          d: icon.path
+          fill: this.color || `#${icon.hex}`,
+          width: this.iconSize,
+          height: this.iconSize,
+          viewBox: "0 0 24 24",
+          xmlns: "http://www.w3.org/2000/svg"
         }
-      })
-    ]);
+      },
+      [
+        createElement("title", title),
+        createElement("path", {
+          attrs: {
+            d: icon.path
+          }
+        })
+      ]
+    );
   }
 })
 export default class VueSimpleIcon extends Vue {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9730,10 +9730,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-simple-icons@^1.9.28:
-  version "1.9.28"
-  resolved "https://registry.yarnpkg.com/simple-icons/-/simple-icons-1.9.28.tgz#61779099f13fccfc25d80418a770b83a0e8380ce"
-  integrity sha512-TU3kv2rYTnnBwhe0XajUfDr6FvMeJ6fJeva/UGwLHyeCuEUfDIt0vIDV+dAShRi2IZS9KXkWP3xOnJH7JB36dw==
+simple-icons@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/simple-icons/-/simple-icons-1.10.0.tgz#8e0b4a48c4bdb144c9b7617dd4ee79bac76d3a47"
+  integrity sha512-RA2rXWqWibKx+kU0b4Dce0bN8Nd3ECHXXHCGcZDJ38sE2WMQx0QjzoUqKNLwb4+oAzDTfubOvQBUnFgpLhMdyw==
 
 simple-swizzle@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
<!-- Checklist -->
- [x] I've read the Contributing Guidelines and the Code of Conduct


# Description
<!-- Describe your changes here -->
Update simple-icons dependency to v1.10.0 (https://github.com/simple-icons/simple-icons/pull/1503) and utilize the new `path` property of exported icons in the rendering logic.


# Why is this change required?
n/a


# How did you test that?
The result should equal the original logic, so the original test suites should apply here as well.
