### PR TITLE
Let Travis CI build the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,25 @@
+node_js:
+  - node
+  - lts/*
+  - v8
 jobs:
   include:
     - stage: "Test"
       name: "Unit"
       language: node_js
-      node_js:
-        - node
-        - lts/*
-        - v8
+      node_js: node
       script:
         - yarn unit
       after_script:
         codecov
     - name: "Lint"
       language: node_js
-      node_js:
-        - node
-        - lts/*
-        - v8
+      node_js: node
       script:
         - yarn lint
     - name: "Build"
       language: node_js
-      node_js:
-        - node
-        - lts/*
-        - v8
+      node_js: node
       script:
         - yarn build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
-node_js:
-  - node
-  - lts/*
-  - v8
 jobs:
   include:
     - stage: "Test"
-      name: "Unit"
+      name: "Unit (lts)"
+      language: node_js
+      node_js: lts/*
+      script:
+        - yarn unit
+    - stage: "Test"
+      name: "Unit (v8)"
+      language: node_js
+      node_js: - v8
+      script:
+        - yarn unit
+    - stage: "Test"
+      name: "Unit (node)"
       language: node_js
       node_js: node
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,26 @@
-language: node_js
-env:
-  - TEST_SUITE=unit
-  - TEST_SUITE=lint
-node_js:
-  - node
-  - lts/*
-  - v8
-install:
-  - npm install -g codecov
-  - yarn
-script:
-  - yarn $TEST_SUITE
-  - if [ "$TEST_SUITE" == "unit" ]; then codecov; fi
+jobs:
+  include:
+    - stage: "Test"
+      name: "Unit"
+      language: node_js
+      node_js:
+        - node
+        - lts/*
+        - v8
+      script:
+        - yarn unit
+      after_script:
+        codecov
+    - name: "Lint"
+      language: node_js
+      node_js:
+        - node
+        - lts/*
+        - v8
+      script:
+        - yarn lint
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,14 @@ jobs:
         - v8
       script:
         - yarn lint
+    - name: "Build"
+      language: node_js
+      node_js:
+        - node
+        - lts/*
+        - v8
+      script:
+        - yarn build
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,28 @@
+language: node_js
 jobs:
   include:
     - stage: "Test"
       name: "Unit (lts)"
-      language: node_js
       node_js: lts/*
       script:
         - yarn unit
     - stage: "Test"
       name: "Unit (v8)"
-      language: node_js
       node_js: v8
       script:
         - yarn unit
     - stage: "Test"
       name: "Unit (node)"
-      language: node_js
       node_js: node
       script:
         - yarn unit
       after_script:
         codecov
     - name: "Lint"
-      language: node_js
       node_js: node
       script:
         - yarn lint
     - name: "Build"
-      language: node_js
       node_js: node
       script:
         - yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
     - stage: "Test"
       name: "Unit (v8)"
       language: node_js
-      node_js: - v8
+      node_js: v8
       script:
         - yarn unit
     - stage: "Test"


### PR DESCRIPTION
<!-- Checklist -->
- [x] I've read the Contributing Guidelines and the Code of Conduct


# Description
<!-- Describe your changes here -->
Changes the Travis CI configuration to use stages. On top of that the CI now builds (i.e. `yarn build`) the project.

Also added configuration for the notifications by Travis CI, I'm personally not a fan of receiving an email if the build succeeded, but I'm OK with restoring the original notifications configuration.

# Why is this change required?
<!-- e.g. fix #1234 -->
Fix #94, needed to automatically test changes such as #93


# How did you test that?
<!-- e.g. unit, playground or none -->
Have a look at the build for this PR 😉 