### PR TITLE
Update the label used by Greenkeeper

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -6,5 +6,6 @@
         "playground/package.json"
       ]
     }
-  }
+  },
+  "label": "dependencies"
 }

--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -6,6 +6,5 @@
         "playground/package.json"
       ]
     }
-  },
-  "label": "dependencies"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
       "commitMessage": "chore: release ${version}",
       "tagAnnotation": "Release ${version} :gift:"
     }
+  },
+  "greenkeeper": {
+    "label": "dependencies"
   }
 }


### PR DESCRIPTION
<!-- Checklist -->
- [x] I've read the Contributing Guidelines and the Code of Conduct


# Description
<!-- Describe your changes here -->
Update the label used by Greenkeeper to "dependecies". As per (no official documentation as far as I know): https://github.com/greenkeeperio/greenkeeper/issues/153#issuecomment-232732350

This brings it in line with the PRs generated by dependabot for security fixes (e.g. #79). It is also just clearer in my opinion, especially for people that don't know Greenkeeper.

# Why is this change required?
<!-- e.g. fix #1234 -->
n/a

# How did you test that?
<!-- e.g. unit, playground or none -->
Can't test it until this is merged and Greenkeeper opens a new PR 🤷‍♂ 