### PR TITLE
Minify(/uglify) package build

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "rimraf": "^2.6.3",
     "rollup": "^1.15.6",
     "rollup-plugin-typescript2": "^0.21.2",
+    "rollup-plugin-uglify": "^6.0.2",
     "ts-jest": "^24.0.0",
     "typescript": "^3.3.4000",
     "typescript-eslint-parser": "^21.0.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,20 +1,31 @@
 import typescript from "rollup-plugin-typescript2";
+import { uglify } from "rollup-plugin-uglify";
 
-export default {
-  input: "./src/index.ts",
+export default [
+  {
+    input: "./src/index.ts",
 
-  plugins: [typescript()],
+    plugins: [typescript(), uglify()],
 
-  output: [
-    {
-      file: "dist/vue-simpleicons.umd.js",
-      format: "umd",
-      name: "vueSimpleIcons"
-    },
-    {
-      file: "dist/vue-simpleicons.esm.js",
-      format: "esm",
-      name: "vueSimpleIcons"
-    }
-  ]
-};
+    output: [
+      {
+        file: "dist/vue-simpleicons.umd.js",
+        format: "umd",
+        name: "vueSimpleIcons"
+      }
+    ]
+  },
+  {
+    input: "./src/index.ts",
+
+    plugins: [typescript()],
+
+    output: [
+      {
+        file: "dist/vue-simpleicons.esm.js",
+        format: "esm",
+        name: "vueSimpleIcons"
+      }
+    ]
+  }
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -6009,7 +6009,7 @@ jest-watcher@^24.8.0:
     jest-util "^24.8.0"
     string-length "^2.0.0"
 
-jest-worker@^24.6.0:
+jest-worker@^24.0.0, jest-worker@^24.6.0:
   version "24.6.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.6.0.tgz#7f81ceae34b7cde0c9827a6980c35b7cdc0161b3"
   integrity sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==
@@ -8742,6 +8742,16 @@ rollup-plugin-typescript2@^0.21.2:
     rollup-pluginutils "2.6.0"
     tslib "1.9.3"
 
+rollup-plugin-uglify@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.2.tgz#681042cfdf7ea4e514971946344e1a95bc2772fe"
+  integrity sha512-qwz2Tryspn5QGtPUowq5oumKSxANKdrnfz7C0jm4lKxvRDsNe/hSGsB9FntUul7UeC4TsZEWKErVgE1qWSO0gw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    jest-worker "^24.0.0"
+    serialize-javascript "^1.6.1"
+    uglify-js "^3.4.9"
+
 rollup-pluginutils@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz#203706edd43dfafeaebc355d7351119402fc83ad"
@@ -8917,7 +8927,7 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.3.0, serialize-javascript@^1.7.0:
+serialize-javascript@^1.3.0, serialize-javascript@^1.6.1, serialize-javascript@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
   integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
@@ -9876,7 +9886,7 @@ uglify-js@3.4.x:
     commander "~2.19.0"
     source-map "~0.6.1"
 
-uglify-js@^3.1.4:
+uglify-js@^3.1.4, uglify-js@^3.4.9:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
   integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==


### PR DESCRIPTION
<!-- Checklist -->
- [x] I've read the Contributing Guidelines and the Code of Conduct


# Description
<!-- Describe your changes here -->
Added a plugin to the Rollup build that minifies the `umd` output. Ideally we also minify the `esm` output, but I didn't get that working with the plugin that I used ([rolllup-plugin-uglify](https://www.npmjs.com/package/rollup-plugin-uglify)) quickly. Any help in this regard @sh7dm ?

# Why is this change required?
<!-- e.g. fix #1234 -->
Reducing package size is always a plus.

# How did you test that?
<!-- e.g. unit, playground or none -->
I trust [rolllup-plugin-uglify](https://www.npmjs.com/package/rollup-plugin-uglify) works as expected, but it is not a bad idea to test the build package as well 🤔 