### PR TITLE
Update monorepo.commitlint to the latest version 🚀 

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "es2015": "dist/vue-simpleicons.esm.js",
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",
-    "@commitlint/config-conventional": "^8.0.0",
+    "@commitlint/config-conventional": "^8.1.0",
     "@types/jest": "^24.0.11",
     "@vue/test-utils": "^1.0.0-beta.27",
     "@vuepress/plugin-pwa": "^1.0.0-alpha.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "module": "dist/vue-simpleicons.esm.js",
   "es2015": "dist/vue-simpleicons.esm.js",
   "devDependencies": {
-    "@commitlint/cli": "^8.0.0",
+    "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.0.0",
     "@types/jest": "^24.0.11",
     "@vue/test-utils": "^1.0.0-beta.27",


### PR DESCRIPTION

This monorepo update includes releases of one or more dependencies which all belong to the [commitlint group definition](https://github.com/greenkeeperio/monorepo-definitions).


commitlint is a devDependency of this project. It **might not break your production code or affect downstream projects**, but probably breaks your build or test tools, which may **prevent deploying or publishing**.



<details>
<summary>Status Details</summary>

- ❌ **continuous-integration/travis-ci/push:** The Travis CI build could not complete due to an error ([Details](https://travis-ci.org/sh7dm/vue-simpleicons/builds/559073391?utm_source=github_status&utm_medium=notification)).
</details>


---

<details>
<summary>Commits</summary>
<p>The new version differs by 39 commits.</p>
<ul>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/c17420d67adafdf37f68d6861d29a0e85a4a3bd7"><code>c17420d</code></a> <code>v8.1.0</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/ca19d70b2c73b2857d4bfbd483c6c7929d946ad6"><code>ca19d70</code></a> <code>chore: update dependency lodash to v4.17.14 (#724)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/5757ef28fd1051ff697b86b8bea19aa508faf604"><code>5757ef2</code></a> <code>build(deps): bump lodash.template from 4.4.0 to 4.5.0 (#721)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/5b5f8557e432cb275cb1ff3f6684edf32278ae6c"><code>5b5f855</code></a> <code>build(deps): bump lodash.merge from 4.6.0 to 4.6.2 (#722)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/4cb979df81328684467fd0dad130440ce725831d"><code>4cb979d</code></a> <code>build(deps): bump lodash from 4.17.11 to 4.17.13 (#723)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/a89c1ba8292d4ca8be4e06d60cc00ce21ddd960b"><code>a89c1ba</code></a> <code>chore: add devcontainer setup</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/9aa57094814f8b55e352c997025e2a00d0d1f00d"><code>9aa5709</code></a> <code>chore: pin dependencies (#714)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/c9ef5e2c40fdd834775b400937fafaf4ca28ee04"><code>c9ef5e2</code></a> <code>chore: centralize typescript and jest setups (#710)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/c9dcf1a0996335faf02daf3d707ab1a328865ee8"><code>c9dcf1a</code></a> <code>chore: pin dependencies (#708)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/6a6a8b070995cd98e4be57ebc7f3ed25ecaa8179"><code>6a6a8b0</code></a> <code>refactor: rewrite top level to typescript (#679)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/0fedbc09fbbd838f75ecae7d90345e28f66ff84a"><code>0fedbc0</code></a> <code>chore: update dependency @types/jest to v24.0.15 (#694)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/0b9c7ed4aff7a1c0208cafb2f6fd53bce450d416"><code>0b9c7ed</code></a> <code>chore: update dependency typescript to v3.5.2 (#695)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/4efb34b8023aff05ebdcffb9d8e34be447e84c88"><code>4efb34b</code></a> <code>chore: update dependency globby to v10 (#705)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/804af8bcbf3fb8a4197040b5ba7c96e692fbd1f6"><code>804af8b</code></a> <code>chore: update dependency lint-staged to v8.2.1 (#696)</code></li>
<li><a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/commit/90758444079470763d0d7b9f6344f40d471a8eb3"><code>9075844</code></a> <code>fix: add explicit dependency on chalk (#687)</code></li>
</ul>
<p>There are 39 commits in total.</p>
<p>See the <a href="https://urls.greenkeeper.io/conventional-changelog/commitlint/compare/29d1cee10ee7734a85d97ef039c4ce2da633628c...c17420d67adafdf37f68d6861d29a0e85a4a3bd7">full diff</a></p>
</details>


---


Closes #97